### PR TITLE
Get rid of broken syntax highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Proverbs from @rob_pike's inspiring talk at Gopherfest SV 2015 (video)
 
 
-```bash
+```
 go run github.com/andriisoldatenko/proverbs
 
 Go Proverbs, by Rob Pike


### PR DESCRIPTION
Proverbs list in a README marked as `bash` that enables syntax highlighting for it. However, it shouldn't be highlighted in that way. Now it tries to parse `'` sign as string quotes.

![image](https://user-images.githubusercontent.com/9638362/64113850-aee67d80-cd8b-11e9-9413-4b1a8a0ca42d.png)
Black becomes blue here